### PR TITLE
Compact code related to model generation for PrismaticActiveBlock

### DIFF
--- a/src/generated/resources/assets/monilabs/lang/en_ud.json
+++ b/src/generated/resources/assets/monilabs/lang/en_ud.json
@@ -3,6 +3,7 @@
   "block.monilabs.chromodynamic_conduction_casing": "buısɐƆ uoıʇɔnpuoƆ ɔıɯɐuʎpoɯoɹɥƆ",
   "block.monilabs.knowledge_transmission_array": "ʎɐɹɹⱯ uoıssıɯsuɐɹ⟘ ǝbpǝןʍouʞ",
   "block.monilabs.prismatic_focus": "snɔoℲ ɔıʇɐɯsıɹԀ",
+  "block.monilabs.xp_hatch": "ɥɔʇɐH ԀX",
   "config.jade.plugin_monilabs.color_info": "oɟuI ɹoןoƆ ǝןqıɔnɹƆ ɔıʇɐɯsıɹԀ",
   "gtceu.antimatter_manipulator": "uoıʇɐןndıuɐW ɹǝʇʇɐɯıʇuⱯ",
   "itemGroup.monilabs.creative_tab": ")poɯǝɹoƆ( sqɐꞀ ıuoW",

--- a/src/generated/resources/assets/monilabs/lang/en_us.json
+++ b/src/generated/resources/assets/monilabs/lang/en_us.json
@@ -3,6 +3,7 @@
   "block.monilabs.chromodynamic_conduction_casing": "Chromodynamic Conduction Casing",
   "block.monilabs.knowledge_transmission_array": "Knowledge Transmission Array",
   "block.monilabs.prismatic_focus": "Prismatic Focus",
+  "block.monilabs.xp_hatch": "XP Hatch",
   "config.jade.plugin_monilabs.color_info": "Prismatic Crucible Color Info",
   "gtceu.antimatter_manipulator": "Antimatter Manipulation",
   "itemGroup.monilabs.creative_tab": "Moni Labs (Coremod)",

--- a/src/main/java/net/neganote/monilabs/common/block/PrismaticActiveBlock.java
+++ b/src/main/java/net/neganote/monilabs/common/block/PrismaticActiveBlock.java
@@ -1,9 +1,7 @@
 package net.neganote.monilabs.common.block;
 
 import com.gregtechceu.gtceu.api.block.ActiveBlock;
-import com.tterrag.registrate.providers.DataGenContext;
-import com.tterrag.registrate.providers.RegistrateBlockstateProvider;
-import com.tterrag.registrate.util.nullness.NonNullBiConsumer;
+
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
@@ -12,6 +10,10 @@ import net.minecraft.world.level.block.state.properties.IntegerProperty;
 import net.minecraftforge.client.model.generators.ModelFile;
 import net.minecraftforge.client.model.generators.VariantBlockStateBuilder;
 import net.neganote.monilabs.common.machine.multiblock.PrismaticCrucibleMachine.Color;
+
+import com.tterrag.registrate.providers.DataGenContext;
+import com.tterrag.registrate.providers.RegistrateBlockstateProvider;
+import com.tterrag.registrate.util.nullness.NonNullBiConsumer;
 import org.jetbrains.annotations.NotNull;
 
 public class PrismaticActiveBlock extends ActiveBlock {
@@ -35,32 +37,32 @@ public class PrismaticActiveBlock extends ActiveBlock {
             ActiveBlock block = ctx.getEntry();
 
             ModelFile inactive = prov
-                .models()
-                .cubeAll(texturePath.getPath(),
-                    texturePath.withPrefix("block/"));
+                    .models()
+                    .cubeAll(texturePath.getPath(),
+                            texturePath.withPrefix("block/"));
 
             VariantBlockStateBuilder builder = prov
-                .getVariantBuilder(block)
-                .partialState()
-                .with(ActiveBlock.ACTIVE, false)
-                .modelForState()
-                .modelFile(inactive)
-                .addModel();
+                    .getVariantBuilder(block)
+                    .partialState()
+                    .with(ActiveBlock.ACTIVE, false)
+                    .modelForState()
+                    .modelFile(inactive)
+                    .addModel();
 
             ResourceLocation location = texturePath.withPrefix("block/");
             for (Color color : Color.ACTUAL_COLORS) {
                 String colorStr = "_" + color.name().toLowerCase();
                 ModelFile file = prov
-                    .models()
-                    .cubeAll(name + colorStr, location.withSuffix(colorStr));
+                        .models()
+                        .cubeAll(name + colorStr, location.withSuffix(colorStr));
 
                 builder
-                    .partialState()
-                    .with(ActiveBlock.ACTIVE, true)
-                    .with(COLOR, color.key)
-                    .modelForState()
-                    .modelFile(file)
-                    .addModel();
+                        .partialState()
+                        .with(ActiveBlock.ACTIVE, true)
+                        .with(COLOR, color.key)
+                        .modelForState()
+                        .modelFile(file)
+                        .addModel();
             }
         };
     }


### PR DESCRIPTION
Seeing the old implementation made me so horrified I was forced to write this improvement. Technically makes the enum names matter, but why are they ever gonna change from being color names (and if we really want, the color names could be a property of the enum). In return it means less duplicated code to manage.

Untested because idk how to make a Prismatic Cruicible in dev, but I'd never write bugs so no reason to test anyway.