### PR TITLE
Fix: add auto-complete card support for extended pattern providers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -247,6 +247,8 @@ dependencies {
 
     // AAE because we need to redo their mixin
     modCompileOnly("maven.modrinth:advancedae:${aae_version}")
+
+    modCompileOnly("curse.maven:ex-pattern-provider-892005:8291632")
 }
 
 tasks.named('processResources', ProcessResources).configure {

--- a/src/main/java/net/neganote/monilabs/mixin/MixinEAERegistryHandler.java
+++ b/src/main/java/net/neganote/monilabs/mixin/MixinEAERegistryHandler.java
@@ -1,10 +1,11 @@
 package net.neganote.monilabs.mixin;
 
+import net.minecraft.world.level.ItemLike;
+
 import appeng.api.upgrades.Upgrades;
 import appeng.core.definitions.AEItems;
 import com.glodblock.github.extendedae.common.EAERegistryHandler;
 import com.glodblock.github.extendedae.common.EPPItemAndBlock;
-import net.minecraft.world.level.ItemLike;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;

--- a/src/main/java/net/neganote/monilabs/mixin/MixinEAERegistryHandler.java
+++ b/src/main/java/net/neganote/monilabs/mixin/MixinEAERegistryHandler.java
@@ -1,0 +1,21 @@
+package net.neganote.monilabs.mixin;
+
+import appeng.api.upgrades.Upgrades;
+import appeng.core.definitions.AEItems;
+import com.glodblock.github.extendedae.common.EAERegistryHandler;
+import com.glodblock.github.extendedae.common.EPPItemAndBlock;
+import net.minecraft.world.level.ItemLike;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(EAERegistryHandler.class)
+public class MixinEAERegistryHandler {
+
+    @Inject(method = "registerAEUpgrade", at = @At("TAIL"), remap = false)
+    private void injectAutoCompleteCard(CallbackInfo ci) {
+        Upgrades.add((ItemLike) AEItems.AUTO_COMPLETE_CARD, (ItemLike) EPPItemAndBlock.EX_PATTERN_PROVIDER, 1);
+        Upgrades.add((ItemLike) AEItems.AUTO_COMPLETE_CARD, (ItemLike) EPPItemAndBlock.EX_PATTERN_PROVIDER_PART, 1);
+    }
+}

--- a/src/main/resources/monilabs.mixins.json
+++ b/src/main/resources/monilabs.mixins.json
@@ -16,6 +16,7 @@
     "aae.MixinEncodedPatternItemShim",
     "aae.MixinGuiTextShim",
     "aae.MixinPatternDetailsHelperShim",
+    "MixinEAERegistryHandler",
     "aae.MixinProcessingPatternItemShim"
   ],
   "client":


### PR DESCRIPTION
Vanilla pattern providers support auto completion cards but extended versions do not. I've fixed it using mixin.