### PR TITLE
Bump version to 0.21.8

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
-# Moni Labs 0.21.7
+# Moni Labs 0.21.8
 
-* TES now notifies machines that they have energy available when on, allowing them to work without replacing the machines
+* Fix rare error from the TES shader asking for a texture slot it can't get (thanks JenyaRostov)
+* Add auto-complete card support for extended pattern providers (thanks tamer bayar)
+* Add internal static var for an overclocks-as-parallels recipe modifier

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ org.gradle.jvmargs=-Xmx1G
     mapping_version=2023.09.03
 
 # Mod Properties
-    mod_version=0.21.7
+    mod_version=0.21.8
     maven_group=net.neganote.monilabs
     archives_base_name=monilabs
     mod_id=monilabs


### PR DESCRIPTION
* Fix rare error from the TES shader asking for a texture slot it can't get (thanks JenyaRostov)
* Add auto-complete card support for extended pattern providers (thanks tamer bayar)
* Add internal static var for an overclocks-as-parallels recipe modifier