### PR TITLE
fix TES causing a radnom stackoverflows

### DIFF
--- a/src/main/java/net/neganote/monilabs/common/machine/multiblock/CreativeEnergyMultiMachine.java
+++ b/src/main/java/net/neganote/monilabs/common/machine/multiblock/CreativeEnergyMultiMachine.java
@@ -8,7 +8,6 @@ import com.gregtechceu.gtceu.common.machine.owner.MachineOwner;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraftforge.server.ServerLifecycleHooks;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -110,17 +109,14 @@ public class CreativeEnergyMultiMachine extends UniqueWorkableElectricMultiblock
     }
 
     private static List<NotifiableEnergyContainer> collectContainersInTeamOf(UUID teamMemberUUID) {
-        List<NotifiableEnergyContainer> inTeam = new ArrayList<>();
-        for (NotifiableEnergyContainer container : LOADED_ENERGY_CONTAINERS) {
-            UUID containerOwnerUUID = container.getMachine().getOwnerUUID();
-            if (containerOwnerUUID == null) continue;
-
-            MachineOwner containerOwner = MachineOwner.getOwner(containerOwnerUUID);
-            if (containerOwner != null && containerOwner.isPlayerInTeam(teamMemberUUID)) {
-                inTeam.add(container);
-            }
-        }
-        return inTeam;
+        return LOADED_ENERGY_CONTAINERS.stream()
+                .filter(container -> {
+                    UUID containerOwnerUUID = container.getMachine().getOwnerUUID();
+                    if (containerOwnerUUID == null) return false;
+                    MachineOwner containerOwner = MachineOwner.getOwner(containerOwnerUUID);
+                    return containerOwner != null && containerOwner.isPlayerInTeam(teamMemberUUID);
+                })
+                .toList();
     }
 
     @Override

--- a/src/main/java/net/neganote/monilabs/common/machine/multiblock/CreativeEnergyMultiMachine.java
+++ b/src/main/java/net/neganote/monilabs/common/machine/multiblock/CreativeEnergyMultiMachine.java
@@ -2,21 +2,31 @@ package net.neganote.monilabs.common.machine.multiblock;
 
 import com.gregtechceu.gtceu.api.machine.ConditionalSubscriptionHandler;
 import com.gregtechceu.gtceu.api.machine.IMachineBlockEntity;
+import com.gregtechceu.gtceu.api.machine.trait.NotifiableEnergyContainer;
 import com.gregtechceu.gtceu.common.machine.owner.MachineOwner;
 
 import net.minecraft.server.level.ServerLevel;
 import net.minecraftforge.server.ServerLifecycleHooks;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 @SuppressWarnings("unused")
 public class CreativeEnergyMultiMachine extends UniqueWorkableElectricMultiblockMachine {
 
-    private static final Map<UUID, Integer> ACTIVE_OWNER_COUNTS = new HashMap<>();
+    private static final Set<UUID> ACTIVE_OWNERS = new HashSet<>();
 
     private static final Map<UUID, CacheEntry> PLAYER_CACHE = new HashMap<>();
+
+    private static final Set<NotifiableEnergyContainer> LOADED_ENERGY_CONTAINERS = Collections
+            .newSetFromMap(new IdentityHashMap<>());
 
     private static final int CACHE_LIFETIME_TICKS = 20;
 
@@ -33,8 +43,18 @@ public class CreativeEnergyMultiMachine extends UniqueWorkableElectricMultiblock
                 this::isSubscriptionActive);
     }
 
+    public static void registerEnergyContainer(NotifiableEnergyContainer container) {
+        LOADED_ENERGY_CONTAINERS.add(container);
+    }
+
+    public static void unregisterEnergyContainer(NotifiableEnergyContainer container) {
+        LOADED_ENERGY_CONTAINERS.remove(container);
+    }
+
     public static boolean isCreativeEnergyEnabledFor(UUID playerUUID) {
-        if (ACTIVE_OWNER_COUNTS.isEmpty()) return false;
+        if (ACTIVE_OWNERS.isEmpty()) {
+            return false;
+        }
 
         long now = currentTick();
         CacheEntry cached = PLAYER_CACHE.get(playerUUID);
@@ -43,8 +63,7 @@ public class CreativeEnergyMultiMachine extends UniqueWorkableElectricMultiblock
         }
 
         MachineOwner owner = MachineOwner.getOwner(playerUUID);
-        boolean enabled = owner != null &&
-                ACTIVE_OWNER_COUNTS.keySet().stream().anyMatch(owner::isPlayerInTeam);
+        boolean enabled = owner != null && ACTIVE_OWNERS.stream().anyMatch(owner::isPlayerInTeam);
         PLAYER_CACHE.put(playerUUID, new CacheEntry(enabled, now));
         return enabled;
     }
@@ -55,8 +74,9 @@ public class CreativeEnergyMultiMachine extends UniqueWorkableElectricMultiblock
     }
 
     public static void clearActiveOwners() {
-        ACTIVE_OWNER_COUNTS.clear();
+        ACTIVE_OWNERS.clear();
         PLAYER_CACHE.clear();
+        LOADED_ENERGY_CONTAINERS.clear();
     }
 
     @Override
@@ -76,13 +96,31 @@ public class CreativeEnergyMultiMachine extends UniqueWorkableElectricMultiblock
         }
 
         if (enabled) {
-            ACTIVE_OWNER_COUNTS.merge(ownerUUID, 1, Integer::sum);
+            ACTIVE_OWNERS.add(ownerUUID);
         } else {
-            ACTIVE_OWNER_COUNTS.computeIfPresent(ownerUUID, (uuid, count) -> count > 1 ? count - 1 : null);
+            ACTIVE_OWNERS.remove(ownerUUID);
         }
-
         currentlyActive = enabled;
         PLAYER_CACHE.clear();
+
+        for (NotifiableEnergyContainer container : collectContainersInTeamOf(ownerUUID)) {
+            container.checkOutputSubscription();
+            container.notifyListeners();
+        }
+    }
+
+    private static List<NotifiableEnergyContainer> collectContainersInTeamOf(UUID teamMemberUUID) {
+        List<NotifiableEnergyContainer> inTeam = new ArrayList<>();
+        for (NotifiableEnergyContainer container : LOADED_ENERGY_CONTAINERS) {
+            UUID containerOwnerUUID = container.getMachine().getOwnerUUID();
+            if (containerOwnerUUID == null) continue;
+
+            MachineOwner containerOwner = MachineOwner.getOwner(containerOwnerUUID);
+            if (containerOwner != null && containerOwner.isPlayerInTeam(teamMemberUUID)) {
+                inTeam.add(container);
+            }
+        }
+        return inTeam;
     }
 
     @Override

--- a/src/main/java/net/neganote/monilabs/mixin/NotifiableEnergyContainerMixin.java
+++ b/src/main/java/net/neganote/monilabs/mixin/NotifiableEnergyContainerMixin.java
@@ -20,6 +20,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.List;
@@ -55,7 +56,6 @@ public class NotifiableEnergyContainerMixin extends NotifiableRecipeHandlerTrait
             outputSubs = machine.subscribeServerTick(this.outputSubs, this::serverTick);
             UUID uuid = machine.getOwnerUUID();
             if (uuid != null && CreativeEnergyMultiMachine.isCreativeEnergyEnabledFor(uuid)) {
-                notifyListeners();
                 // return 1 less so active transformers won't turn off
                 cir.setReturnValue(getEnergyCapacity() - 1);
             }
@@ -71,10 +71,21 @@ public class NotifiableEnergyContainerMixin extends NotifiableRecipeHandlerTrait
             outputSubs = machine.subscribeServerTick(this.outputSubs, this::serverTick);
             UUID uuid = machine.getOwnerUUID();
             if (uuid != null && CreativeEnergyMultiMachine.isCreativeEnergyEnabledFor(uuid)) {
-                notifyListeners();
                 cir.setReturnValue(energyToAdd);
             }
         }
+    }
+
+    @Inject(method = "onMachineLoad", at = @At(value = "TAIL"))
+    private void monilabs$registerForCreativeEnergy(CallbackInfo ci) {
+        if (getMachine().getLevel() instanceof ServerLevel) {
+            CreativeEnergyMultiMachine.registerEnergyContainer((NotifiableEnergyContainer) (Object) this);
+        }
+    }
+
+    @Inject(method = "onMachineUnLoad", at = @At(value = "HEAD"))
+    private void monilabs$unregisterFromCreativeEnergy(CallbackInfo ci) {
+        CreativeEnergyMultiMachine.unregisterEnergyContainer((NotifiableEnergyContainer) (Object) this);
     }
 
     @Override


### PR DESCRIPTION
I had to remove the notify listeners from the mixin becuase it was causing a stack overflow, also changed the ACTIVE_OWNERS to a Set becuase, only 1 TES is allowed per team anyway, so now the code reflects the mechanics. Now the energy containers register in the TES controller and get notified about the TES working/not working by the controller itself. 